### PR TITLE
Load texture

### DIFF
--- a/ofxVolumetricsGPUCopyExample/addons.make
+++ b/ofxVolumetricsGPUCopyExample/addons.make
@@ -1,0 +1,1 @@
+ofxVolumetrics

--- a/ofxVolumetricsGPUCopyExample/src/main.cpp
+++ b/ofxVolumetricsGPUCopyExample/src/main.cpp
@@ -1,0 +1,10 @@
+#include "ofMain.h"
+#include "ofApp.h"
+
+int main() {
+    ofGLWindowSettings settings;
+    settings.setGLVersion(3, 2);
+    settings.setSize(800, 600);
+    ofCreateWindow(settings);
+    ofRunApp(new ofApp());
+}

--- a/ofxVolumetricsGPUCopyExample/src/ofApp.cpp
+++ b/ofxVolumetricsGPUCopyExample/src/ofApp.cpp
@@ -1,0 +1,103 @@
+#include "ofApp.h"
+
+
+void ofApp::setup()
+{
+    fbo.allocate(256, 256);
+
+    volWidth = 256;
+    volHeight = 256;
+    volDepth = 256;
+
+    cout << "setting up volume data buffer at " << volWidth << "x" << volHeight << "x" << volDepth <<"\n";
+
+    myVolume.setup(volWidth, volHeight, volDepth, ofVec3f(1,1,1),true);
+    myVolume.setRenderSettings(1.0, 1.0, 0.75, 0.1);
+    myVolume.setVolumeTextureFilterMode(GL_LINEAR);
+    linearFilter = true;
+
+    cam.setDistance(1000);
+    cam.enableMouseInput();
+}
+
+
+void ofApp::update()
+{
+    ofSetWindowTitle(ofToString(ofGetFrameRate()));
+}
+
+
+void ofApp::draw()
+{
+    ofSetColor(255,255,255,255);
+    cam.begin();
+    myVolume.drawVolume(0, 0, 0, ofGetHeight(), 0);
+    if (drawDebug) ofDrawAxis(100);
+    cam.end();
+
+    ofSetColor(0,0,0,64);
+    ofDrawRectangle(0,0,270,120);
+    ofSetColor(255,255,255,255);
+
+    ofDrawBitmapString("Volume dimensions: " + ofToString(myVolume.getVolumeWidth()) + "x" + ofToString(myVolume.getVolumeHeight()) + "x" + ofToString(myVolume.getVolumeDepth()) + "\n" +
+                       "FBO quality (q/Q): " + ofToString(myVolume.getRenderWidth()) + "x" + ofToString(myVolume.getRenderHeight()) + "\n" +
+                       "Z quality (z/Z):   " + ofToString(myVolume.getZQuality()) + "\n" +
+                       "Threshold (t/T):   " + ofToString(myVolume.getThreshold()) + "\n" +
+                       "Density (d/D):     " + ofToString(myVolume.getDensity()) + "\n" +
+                       "Filter mode (l/n): " + (linearFilter ? "linear" : "nearest") + "\n" +
+                       "Draw debug (b):    " + (drawDebug ? "on" : "off"), 20, 25);
+    fbo.begin();
+    for (int x = 0; x < volDepth; x++) {
+        ofClear(0);
+        ofSetColor(ofRandom(255), 12, 0);
+        ofDrawRectangle(ofRandom(20), ofRandom(20), 50, 50);
+        ofSetColor(50, ofRandom(255), 100);
+        ofDrawCircle(90 + ofRandom(20), 90 + ofRandom(20), 50);
+        myVolume.updateTexture(0, 0, x, 0, 0, fbo.getWidth(), fbo.getHeight());
+    }
+    fbo.end();
+}
+
+
+void ofApp::keyPressed(int key)
+{
+    switch(key)
+    {
+    case 't':
+        myVolume.setThreshold(myVolume.getThreshold()-0.01);
+        break;
+    case 'T':
+        myVolume.setThreshold(myVolume.getThreshold()+0.01);
+        break;
+    case 'd':
+        myVolume.setDensity(myVolume.getDensity()-0.01);
+        break;
+    case 'D':
+        myVolume.setDensity(myVolume.getDensity()+0.01);
+        break;
+    case 'q':
+        myVolume.setXyQuality(myVolume.getXyQuality()-0.01);
+        break;
+    case 'Q':
+        myVolume.setXyQuality(myVolume.getXyQuality()+0.01);
+        break;
+    case 'z':
+        myVolume.setZQuality(myVolume.getZQuality()-0.01);
+        break;
+    case 'Z':
+        myVolume.setZQuality(myVolume.getZQuality()+0.01);
+        break;
+    case 'l':
+        myVolume.setVolumeTextureFilterMode(GL_LINEAR);
+        linearFilter = true;
+        break;
+    case 'n':
+        myVolume.setVolumeTextureFilterMode(GL_NEAREST);
+        linearFilter = false;
+        break;
+    case 'b':
+        drawDebug = !drawDebug;
+        myVolume.setDrawDebugVolume(drawDebug);
+        break;
+    }
+}

--- a/ofxVolumetricsGPUCopyExample/src/ofApp.h
+++ b/ofxVolumetricsGPUCopyExample/src/ofApp.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "ofMain.h"
+#include "ofxVolumetrics.h"
+
+class ofApp : public ofBaseApp
+{
+public:
+
+    void setup();
+    void update();
+    void draw();
+    void keyPressed  (int key);
+   
+    ofEasyCam cam;
+    
+    ofxVolumetrics myVolume;
+    int volWidth, volHeight, volDepth;
+    ofImage background;
+    ofFbo fbo;
+    bool linearFilter;
+    bool drawDebug;
+};

--- a/src/ofxTexture3d.cpp
+++ b/src/ofxTexture3d.cpp
@@ -88,6 +88,13 @@ void ofxTexture3d::loadData(void* data, int w, int h, int d, int xOffset, int yO
 
 }
 
+void ofxTexture3d::loadTexture(int xOffset, int yOffset, int zOffset, int x, int y, int width, int height) {
+	glEnable(texData.textureTarget);
+	glBindTexture(texData.textureTarget, (GLuint)texData.textureID);
+	glCopyTexSubImage3D(texData.textureTarget, 0, xOffset, yOffset, zOffset, x, y, width, height);
+	glDisable(texData.textureTarget);
+}
+
 void ofxTexture3d::clear() {
 	release(texData.textureID);
 	texData.textureID = 0;

--- a/src/ofxTexture3d.h
+++ b/src/ofxTexture3d.h
@@ -45,6 +45,7 @@ public:
 	void loadData(ofPixels& pix, int d, int xOffset, int yOffset, int zOffset);
 	void loadData(ofShortPixels& pix, int d, int xOffset, int yOffset, int zOffset);
 	void loadData(ofFloatPixels& pix, int d, int xOffset, int yOffset, int zOffset);
+	void loadTexture(int xOffset, int yOffset, int zOffset, int x, int y, int width, int height);
 	void bind();
 	void bindAsImage(GLuint unit, GLenum access, GLint level = 0, GLboolean layered = GL_TRUE, GLint layer = 0);
 	void unbind();

--- a/src/ofxVolumetrics.cpp
+++ b/src/ofxVolumetrics.cpp
@@ -115,6 +115,10 @@ void ofxVolumetrics::updateVolumeData(unsigned char* data, int w, int h, int d, 
 	volumeTexture.loadData(data, w, h, d, xOffset, yOffset, zOffset, GL_RGBA);
 }
 
+void ofxVolumetrics::updateTexture(int xOffset, int yOffset, int zOffset, int x, int y, int width, int height) {
+	volumeTexture.loadTexture(xOffset, yOffset, zOffset, x, y, width, height);
+}
+
 void ofxVolumetrics::drawVolume(float x, float y, float z, float size, int zTexOffset) {
 	vec3 volumeSize = voxelRatio * vec3(volWidth, volHeight, volDepth);
 	float maxDim = glm::max(glm::max(volumeSize.x, volumeSize.y), volumeSize.z);

--- a/src/ofxVolumetrics.cpp
+++ b/src/ofxVolumetrics.cpp
@@ -272,3 +272,7 @@ float ofxVolumetrics::getDensity() {
 const ofFbo& ofxVolumetrics::getFbo() const {
 	return fboRender;
 }
+
+ofxTextureData3d ofxVolumetrics::getTextureData() {
+	return volumeTexture.getTextureData();
+}

--- a/src/ofxVolumetrics.h
+++ b/src/ofxVolumetrics.h
@@ -25,6 +25,7 @@ public:
 	void destroy();
 	
 	void updateVolumeData(unsigned char* data, int w, int h, int d, int xOffset, int yOffset, int zOffset);
+	void updateTexture(int xOffset, int yOffset, int zOffset, int x, int y, int width, int height);
 	
 	void drawVolume(float x, float y, float z, float size, int zTexOffset);
 	void drawVolume(float x, float y, float z, float w, float h, float d, int zTexOffset);

--- a/src/ofxVolumetrics.h
+++ b/src/ofxVolumetrics.h
@@ -41,6 +41,7 @@ public:
 	float getZQuality();
 	float getThreshold();
 	float getDensity();
+	ofxTextureData3d getTextureData();
 	
 	void setXyQuality(float q);
 	void setZQuality(float q);


### PR DESCRIPTION
I added loadTexture()... for loading textures instead of pixels.
Maybe it can be optimized, but copying textures seems faster than loading pixels.
I also added an example. Its just a suggestion.
https://forum.openframeworks.cc/t/getting-the-gluint-handle-from-an-ofxvolumetrics-instance/39791/4